### PR TITLE
Support getting and setting multiple outputs at once

### DIFF
--- a/Netio/Device.py
+++ b/Netio/Device.py
@@ -3,7 +3,7 @@ import requests
 import logging
 import json
 from enum import IntEnum
-from typing import List
+from typing import Dict, List
 
 from Netio.exceptions import CommunicationError, AuthError
 
@@ -47,8 +47,11 @@ class Device(object):
         return list(response)[id]
 
     def set_output(self, id: int, action: ACTION = ACTION.NOCHANGE) -> None:
+        self.set_outputs({id: action})
+
+    def set_outputs(self, actions: Dict[int, ACTION]) -> None:
         if self._write_access:
-            self._set_state(id, action)
+            self._set_states(actions)
         else:
             raise AuthError("cannot write, without write access")
 
@@ -144,9 +147,12 @@ class JsonDevice(Device):
             outputs.append(state)
         return outputs
 
-    def _set_state(self, id: int, action) -> dict:
+    def _set_states(self, actions: dict) -> dict:
+        outputs = []
+        for id, action in actions.items():
+            outputs.append({'ID': id, 'Action': action})
 
-        body = {"Outputs": [{"ID": id, "Action": action}]}
+        body = {"Outputs": outputs}
 
         return self._post(body)
 

--- a/Netio/Device.py
+++ b/Netio/Device.py
@@ -44,7 +44,7 @@ class Device(object):
 
     def get_output(self, id: int) -> OUTPUT:
         response = self._get_outputs()
-        return list(response)[id]
+        return next(filter(lambda output: output.ID == id, response))
 
     def get_outputs(self, ids: List[int]) -> List[OUTPUT]:
         # Let's have a real collection of IDs for checking the response IDs

--- a/Netio/Device.py
+++ b/Netio/Device.py
@@ -43,8 +43,15 @@ class Device(object):
         raise NotImplementedError("The function has to be implemented")
 
     def get_output(self, id: int) -> OUTPUT:
-        response = self._get_ouputs()
+        response = self._get_outputs()
         return list(response)[id]
+
+    def get_outputs(self, ids: List[int]) -> List[OUTPUT]:
+        # Let's have a real collection of IDs for checking the response IDs
+        # against.
+        ids = set(ids)
+        response = self._get_outputs()
+        return [output for output in response if output.ID in ids]
 
     def set_output(self, id: int, action: ACTION = ACTION.NOCHANGE) -> None:
         self.set_outputs({id: action})
@@ -121,7 +128,7 @@ class JsonDevice(Device):
                                 verify=self._verify)
         return self._parse_response(response)
 
-    def _get_ouputs(self) -> List[Device.OUTPUT]:
+    def _get_outputs(self) -> List[Device.OUTPUT]:
         """
         Send empty GET request to the device.
         Parse out the output states according to specification.


### PR DESCRIPTION
The JSON request may affect all outputs and the JSON response always contains information for all outputs. So it would be nice to have the option to set and get for multiple outputs at once.

I made this additions while porting an older command line interface onto PyNetio. But they seem generally useful to me.

In addition, b2dd071 fixes an off-by-one issue betwen `set_output` and `get_output`. The former takes the ID as the ID in the JSON data (starting at one). The latter as index to the response list (starting at zero). The former behaviour seems more intuitive to me, so I went for this one. I hope your are O.K. with this drive-by fix without opening an issue.